### PR TITLE
Update CC3000_xively.ino

### DIFF
--- a/CC3000_xively/CC3000_xively.ino
+++ b/CC3000_xively/CC3000_xively.ino
@@ -189,6 +189,9 @@ void sendData(Adafruit_CC3000_Client& client, String input, int chunkSize) {
   int length = input.length();
   int max_iteration = (int)(length/chunkSize);
   
+  if(max_iteration*chunkSize < length)
+    max_iteration++;
+    
   for (int i = 0; i < length; i++) {
     client.print(input.substring(i*chunkSize, (i+1)*chunkSize));
     wdt_reset();


### PR DESCRIPTION
for any chunkSize (which is 20 right now in our code), if the length of data is not multiple of 20, max_iteration obtained will be one less than required. Hence while sending the data in loop in sendData() , we can't be able to send the complete data(leading to corrupted data)  which will lead to failure in passing data to xively. for example if length is 157, max_iteration = (int)(length/chunkSize) = max_iteration = (int)(157/20) = 7. so, 7 iterations of loop will follow and 140 bytes (7 \* 20)  of data will be sent and remaining 17 will not be sent. hence data sent become corrupted. so, to avoid this situation, we increment the iteration in such cases by 1 by adding following code:
  if(max_iteration*chunkSize < length)
    max_iteration++;
thus max_iteration as per our example becomes 8 and all the data could be sent continuously.
